### PR TITLE
use default help

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -27,11 +27,6 @@ var serverCmd = &cobra.Command{
 	},
 }
 
-func init() {
-	// Register the server command
-	rootCmd.AddCommand(serverCmd)
-}
-
 func executeRemoteCommand(remotePath string) {
 	parts := strings.SplitN(remotePath, "@", 2)
 	if len(parts) != 2 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified command-line interface tool to use default help messages, improving consistency and user experience.
  - Enhanced command initialization process for better maintainability.
  - Improved handling of remote command execution for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->